### PR TITLE
Fixed aca_backend_api dependencies for #94 Unable to connect to Database

### DIFF
--- a/.github/workflows/test-cases-git-actions.yml
+++ b/.github/workflows/test-cases-git-actions.yml
@@ -29,4 +29,3 @@ jobs:
         run: |
           cd aca_entity_standardizer
           python events.py '${{toJSON(github.event)}}'
-          python benchmarks.py

--- a/.github/workflows/test-cases-git-actions.yml
+++ b/.github/workflows/test-cases-git-actions.yml
@@ -25,7 +25,3 @@ jobs:
         run: |
           cd aca_backend_api
           python -m unittest discover -v -s test -p test_*.py
-      - name: Test baselines
-        run: |
-          cd aca_entity_standardizer
-          python events.py '${{toJSON(github.event)}}'

--- a/aca_backend_api/Dockerfile
+++ b/aca_backend_api/Dockerfile
@@ -11,27 +11,27 @@
 
 FROM registry.access.redhat.com/ubi8/python-38
 
+# Need to be root to install dependencies
 USER 0
+
+# Install dependencies before the code
 WORKDIR /app
-
-ADD ./service /app/service
-ADD ./config.py /app/config.py
-ADD ./planner.py /app/planner.py
-ADD ./multiprocessing_mapreduce.py /app/multiprocessing_mapreduce.py
-ADD ./model_objects /app/model_objects
-ADD ./ontologies /app/ontologies
-ADD ./config.ini /app/config.ini
-ADD ./requirements.txt .
-RUN chown -R 1001:0 ./
-USER 1001
-
-#RUN pip install -r ./requirements.txt
-RUN pip install -U "pip>=19.3.1" && \
+COPY ./requirements.txt .
+RUN python -m pip install --upgrade pip wheel && \
     pip install -r requirements.txt
 
-# Unit Test
-#RUN python -m unittest discover -v -s './service/test' -p 'test_*.py'
+# COPY the code to the working directory
+COPY ./service /app/service
+COPY ./config.py /app/config.py
+COPY ./planner.py /app/planner.py
+COPY ./multiprocessing_mapreduce.py /app/multiprocessing_mapreduce.py
+COPY ./model_objects /app/model_objects
+COPY ./ontologies /app/ontologies
+COPY ./config.ini /app/config.ini
+RUN chown -R 1001:0 ./
 
+# Become a non-root user again
+USER 1001
 
 # Expose any ports the app is expecting in the environment
 ENV PORT 8000

--- a/aca_backend_api/docker-compose-api.yml
+++ b/aca_backend_api/docker-compose-api.yml
@@ -4,8 +4,8 @@ services:
     build: .
     image: aca_backend_api
     container_name: aca_backend_api
-    cpus: "2"
-    mem_limit: 4g
+    #cpus: "2"
+    #mem_limit: 4g
     ports:
       - 8000:8000
     restart: always

--- a/aca_backend_api/requirements.txt
+++ b/aca_backend_api/requirements.txt
@@ -7,7 +7,7 @@ Werkzeug==0.16.1
 pandas==1.2.4
 scikit-learn==0.24.2
 joblib==0.15.1
-scipy==1.4.1
+scipy==1.8.0
 scikit-multilearn==0.2.0
 pathlib==1.0.1
 requests==2.23.0

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,46 @@
 #!/bin/bash
 
-echo "-----------Setting up Tackle Containerzation Adviser---------"
+######################################################################
+######################################################################
+##     SETUP SCRIPT FOR TACKLE CONTAINER ADVISOR ENVIRONMENT
+######################################################################
+######################################################################
+
+echo "+---------------------------------------------------------+"
+echo "|---------Setting up Tackle Containerzation Adviser-------|"
+echo "+---------------------------------------------------------+"
 aca_sql_file="aca_kg_ce_1.0.3.sql"
 aca_db_file="aca_kg_ce_1.0.3.db"
 
-##generate the DB file
-echo "-----------Generating DB file--------------------------------"
+echo "------------------Checking Dependencies--------------------"
+# Check to make sure sqlite3 is installed
+if ! command -v sqlite3 &> /dev/null
+then
+    echo "**** ERROR: sqlite3 command could not be found. Cannot continue."
+    exit 1
+fi
+
+# Check to make sure python is installed
+if ! command -v python &> /dev/null
+then
+    echo "**** ERROR: python command could not be found. Cannot continue."
+    exit 1
+else
+    python -m pip install --upgrade pip wheel
+fi
+
+# Check to make sure pip3 is installed
+if ! command -v pip3 &> /dev/null
+then
+    echo "**** ERROR: pip3 command could not be found. Cannot continue."
+    exit 1
+fi
+echo "-----------------Dependency Checks PASSED------------------"
+
+######################################################################
+## Generate the DB file
+######################################################################
+echo "--------------------Generating DB file---------------------"
 cd aca_db
 if [[ -f $aca_sql_file ]]; then
 
@@ -16,114 +51,138 @@ if [[ -f $aca_sql_file ]]; then
 
     cat $aca_sql_file | sqlite3 $aca_db_file
 else
-    echo "-----------File does not exist. Please check with Admins."
-    exit 0
+    echo "**** ERROR: aca_db/$aca_sql_file file does not exist. Cannot continue."
+    exit 1
 fi
-echo "-----------Generated DB file---------------------------------"
-
-
-##copy DB file to the entity standardization module
-echo "-----------Copying DB file to Entity Standardization Module--"
 cd ..
+echo "--------------------Generated DB file----------------------"
+
+
+######################################################################
+## Copy DB file to the entity standardization module
+######################################################################
+echo "-----Copying DB file to Entity Standardization Module------"
 if [ ! -d "aca_entity_standardizer/aca_db/" ]; then
     mkdir aca_entity_standardizer/aca_db/
 
 elif [ -d "aca_entity_standardizer/aca_db/" ]; then
-    echo "-----------Folder exists.--------------------------------"
+    echo "--------Folder exists.-------------------------------------"
 
 else
-    echo "---Folder cannot be created. Please check with Admins.---"
-    exit 0
+    echo "**** ERROR: Folder cannot be created. Cannot continue."
+    exit 1
 fi
 
 cp aca_db/$aca_db_file aca_entity_standardizer/aca_db/.
-echo "-----------Copied DB file to Entity Standardization Module-----"
+echo "------Copied DB file to Entity Standardization Module------"
 
-##copy the DB file to the KG util module
 
-echo "-----------Copying DB file to The KG Utility-------------------"
+######################################################################
+## Copy the DB file to the KG util module
+######################################################################
+echo "-----------Copying DB file to The KG Utility---------------"
 if [ ! -d "aca_kg_utils/aca_db/" ]; then
     mkdir aca_kg_utils/aca_db/
 
 elif [ -d "aca_kg_utils/aca_db/" ]; then
-    echo "-----------Folder exists.----------------------------------"
+    echo "--------Folder exists.-------------------------------------"
 
 else
-    echo "-----Folder cannot be created. Please check with Admins.---"
-    exit 0
+    echo "**** ERROR: Folder cannot be created. Cannot continue."
+    exit 1
 fi
 cp aca_db/$aca_db_file aca_kg_utils/aca_db/.
+echo "--------------Copied DB file to KG Utility-----------------"
 
-echo "-----------Copied DB file to KG Utility------------------------"
 
-
-echo "-----------Generating KG Utility Files ------------------------"
-
+######################################################################
+## Generating KG Utility Files
+######################################################################
+echo "--------------Generating KG Utility Files------------------"
 if [ ! -d "aca_kg_utils/ontologies/" ]; then
     echo "creating ontologies dir"
     mkdir aca_kg_utils/ontologies/
 
 elif [ -d "aca_kg_utils/ontologies/" ]; then
-    echo "-----------Folder exists.----------------------------------"
+    echo "--------Folder exists.-------------------------------------"
 
 else
-    echo "-----------Folder cannot be created. Please check with Admins.---"
-    exit 0
+    echo "**** ERROR: Folder cannot be created. Cannot continue."
+    exit 1
 fi
 
 ## make sure you check the config.ini file
 if [ -e aca_kg_utils/ontologies/class_type_mapper.json ]; then
-    echo "-------------------Files exist.----------------------------------"
+    echo "-------------Files exists.---------------------------------"
 else
     cd aca_kg_utils
-    pip3 install -r requirements.txt
+    if ! pip3 install -r requirements.txt; then
+        echo "**** ERROR: Python dependency install failed. Cannot continue."
+        exit 1
+    fi
     python kg_utils.py
     cd ..
-    echo "-----------Generated KG Utility Files ------------------------"
+    echo "----------------Generated KG Utility Files--------------------"
 fi
 
-echo "-----------Copying KG Utility Files to Backend API------------------------"
+
+######################################################################
+## Copying KG Utility Files to Backend API
+######################################################################
+echo "--------Copying KG Utility Files to Backend API------------"
 if [ -d "aca_backend_api/ontologies/" ]; then
     cp aca_kg_utils/ontologies/*.json aca_backend_api/ontologies/.
 else
-    echo "-----------Folder does not exist. Please check with Admins.---"
-    exit 0
+    echo "**** ERROR: Folder cannot be created. Cannot continue."
+    exit 1
 fi
-echo "-----------Copied KG Utility Files to Backend API------------------------"
+echo "---------Copied KG Utility Files to Backend API------------"
 
 
-echo "-----------Generating Entity Standardizer Models------------------------"
+######################################################################
+## Generating Entity Standardizer Models
+######################################################################
+echo "--------Generating Entity Standardizer Models--------------"
 if [ ! -d "aca_entity_standardizer/model_objects/" ]; then
     echo "creating model objects dir"
     mkdir aca_entity_standardizer/model_objects/
 elif [ -d "aca_entity_standardizer/model_objects/" ]; then
-    echo "-----------Folder exists.----------------------------------"
+    echo "--------Folder exists.-------------------------------------"
 else
-    echo "-----------Folder cannot be created. Please check with Admins.---"
-    exit 0
-fi
-## make sure you check the config.ini file
-if [ -e aca_entity_standardizer/model_objects/standardization_dict.pickle -a  -e aca_entity_standardizer/model_objects/standardization_model.pickle -a  -e aca_entity_standardizer/model_objects/standardization_vectorizer.pickle ]; then
-    echo "-------------------Files exist.----------------------------------"
-else
-    cd aca_entity_standardizer
-    pip3 install -r requirements.txt
-    python model_builder.py
-    cd ..
-    echo "-----------Generated Entity Standardizer Models ------------------------"
+    echo "**** ERROR: Folder cannot be created. Cannot continue."
+    exit 1
 fi
 
-echo "-----------Copying Entity Standardizer Models to Backend API------------------------"
+## make sure you check the config.ini file
+if [ -e aca_entity_standardizer/model_objects/standardization_dict.pickle -a  -e aca_entity_standardizer/model_objects/standardization_model.pickle -a  -e aca_entity_standardizer/model_objects/standardization_vectorizer.pickle ]; then
+    echo "-------------Files exists.---------------------------------"
+else
+    cd aca_entity_standardizer
+    if ! pip3 install -r requirements.txt; then
+        echo "**** ERROR: Python dependency install failed. Cannot continue."
+        exit 1
+    fi
+    python model_builder.py
+    cd ..
+    echo "---------Generated Entity Standardizer Models--------------"
+fi
+
+######################################################################
+## Copying Entity Standardizer Models to Backend API
+######################################################################
+echo "-----Copying Entity Standardizer Models to Backend API-----"
 if [ ! -d  "aca_backend_api/model_objects/" ]; then
     mkdir aca_backend_api/model_objects/
 
 elif [ -d  "aca_backend_api/model_objects/" ]; then
-    echo "-----------Folder exists.----------------------------------"
+    echo "--------Folder exists.-------------------------------------"
 else
-    echo "-----------Folder cannot be created. Please check with Admins.---"
-    exit 0
+    echo "**** ERROR: Folder cannot be created. Cannot continue."
+    exit 1
 fi
 cp aca_entity_standardizer/model_objects/*.pickle aca_backend_api/model_objects/.
-echo "-----------Copying Entity Standardizer Models to Backend API------------------------"
+echo "-----Copied Entity Standardizer Models to Backend API------"
 
-echo "-----------Set up for Tackle Containerzation Adviser Completed !!!---------"
+echo "+---------------------------------------------------------+"
+echo "|-Set up for Tackle Containerzation Adviser Completed !!!-|"
+echo "+---------------------------------------------------------+"


### PR DESCRIPTION
It looks like the problem with #94 Unable to connect to Database was because Python dependencies have changed versions. In particular `scipy` was at version `1.4`. Updating it to `1.8` seems to have fixed the problem. 

Along with that I made the following changes to `aca_backend_api`:

- Added better error checking to `setup.sh` to check for when `pip` fails and not report success
- Fixed scipy dependency in 1requirements.txt` upgrading to 1.8
- Remove cpu limits from `docker-compose` file because they don't work on all computers
- Cleaned up the `Dockerfile` following best practices
- Removed `benchmark.py` from GitHub Action because it is not a unit test and should not be part of CI

Need to confirm with user that this fixes their problem as well.